### PR TITLE
#2.3 Server Side Rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ Nomad Coders의 `NextJS 시작하기` 강좌를 보며 학습한 내용을 정�
 
 - 따로 dotenv 라이브러리를 설치하지 않아도 된다.
 - 클라이언트 파일(브라우저)에서는 변수명이 `NEXT_PUBLIC_`으로 시작하는 환경변수만 참조할 수 있다.
+
+### Server Side Props
+
+- 렌더링 이전에 서버 단에서 `getServerSideProps` 함수가 호출되며, 반환될 객체를 컴포넌트에서 props로 전달 받을 수 있다.
+
+  → 데이터 fetch 등을 서버 단에서 미리 수행할 수 있다. (이 경우 데이터가 html에 포함되므로 JavaScript가 비활성화된 브라우저에서도 완성된 페이지를 볼 수 있음)
+
+- `getServerSideProps` 함수는 `pages/` 하위에 있는 파일에 작성해야 한다.
+- `getServerSideProps` 함수를 반드시 `export`해야 동작한다.
+- `getServerSideProps` 함수 내에서 사용할 URL은 절대경로만 가능하다.

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,14 +1,29 @@
+import { useEffect } from "react";
 import { Seo } from "../components/Seo";
 
-const foo = () => {
+const foo = ({ aboutPageProps }: any) => {
+  const { content } = aboutPageProps;
+
+  useEffect(() => {
+    console.log(aboutPageProps);
+  }, []);
+
   return (
     <>
       <Seo title="About" />
-      <div>
-        <h1>About Us</h1>
-      </div>
+      <h1>{content}</h1>
     </>
   );
+};
+
+export const getServerSideProps = async () => {
+  return {
+    props: {
+      aboutPageProps: {
+        content: "About Us",
+      },
+    },
+  };
 };
 
 export default foo;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Seo } from "../components/Seo";
 
 const httpGetPopularMovies = async () => {
-  const response = await fetch("/api/movies");
+  const response = await fetch("http://localhost:3000/api/movies");
 
   const { results } = await response.json();
 
@@ -20,8 +20,8 @@ interface Movie {
   original_title: string;
 }
 
-const Home = () => {
-  const [movies, setMovies] = useState<Movie[]>();
+const Home = ({ homePageProps, aboutPageProps }: any) => {
+  const { movies }: { movies: Movie[] } = homePageProps;
 
   useEffect(() => {
     console.log(process.env.NEXT_PUBLIC_API_KEY);
@@ -29,23 +29,31 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
-    httpGetPopularMovies().then(setMovies);
+    console.log(aboutPageProps); // undefined
   }, []);
 
   return (
     <div>
       <Seo title="Home" />
-      {movies === undefined ? (
-        <h4>Loading... {movies}</h4>
-      ) : (
-        movies.map(({ id, original_title }) => (
-          <div key={id}>
-            <h4>{original_title}</h4>
-          </div>
-        ))
-      )}
+      {movies.map(({ id, original_title }) => (
+        <div key={id}>
+          <h4>{original_title}</h4>
+        </div>
+      ))}
     </div>
   );
+};
+
+export const getServerSideProps = async () => {
+  const movies = await httpGetPopularMovies();
+
+  return {
+    props: {
+      homePageProps: {
+        movies,
+      },
+    },
+  };
 };
 
 export default Home;


### PR DESCRIPTION
## 나만의 학습정리
### Server Side Props

- 렌더링 이전에 서버 단에서 `getServerSideProps` 함수가 호출되며, 반환될 객체를 컴포넌트에서 props로 전달 받을 수 있다.

  → 데이터 fetch 등을 서버 단에서 미리 수행할 수 있다. (이 경우 데이터가 html에 포함되므로 JavaScript가 비활성화된 브라우저에서도 완성된 페이지를 볼 수 있음)

- `getServerSideProps` 함수는 `pages/` 하위에 있는 파일에 작성해야 한다.
- `getServerSideProps` 함수를 반드시 `export`해야 동작한다.
- `getServerSideProps` 함수 내에서 사용할 URL은 절대경로만 가능하다.